### PR TITLE
[Change] wrap value of lsyncd_fanout_rsync_delete in quotes, its a li…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 lsyncd_fanout_delay: 1
 lsyncd_fanout_max_processes: 4
 lsyncd_fanout_ssh_options: "-o StrictHostKeyChecking=no"
-lsyncd_fanout_rsync_delete: false
+lsyncd_fanout_rsync_delete: "false"
 lsyncd_fanout_rsync_options: "-lturs"
 
 inotify_max_user_watches: 524288

--- a/tasks/lsyncd-fanout.yml
+++ b/tasks/lsyncd-fanout.yml
@@ -5,12 +5,6 @@
     enablerepo: epel
     update_cache: yes
 
-- name: 'Create lsyncd config'
-  template:
-    src: lsyncd.conf.lua.j2
-    dest: /etc/lsyncd.conf
-  notify: Restart lsyncd
-
 - name: 'Create lsyncd shared paths'
   file:
     path: "{{ item }}"
@@ -19,6 +13,12 @@
     group: "root"
     mode: "0750"
   with_items: "{{ lsyncd_fanout_directories }}"
+
+- name: 'Create lsyncd config'
+  template:
+    src: lsyncd.conf.lua.j2
+    dest: /etc/lsyncd.conf
+  notify: Restart lsyncd
 
 - name: 'Set sysctl inotify options for real-time file monitoring'
   sysctl:


### PR DESCRIPTION
…teral true/false that needs to pass to lsyncd LUA; not an ansible true/false

[Change] bumped task to create lsyncd.conf before lsyncd restarts